### PR TITLE
Include ACCESS_FINE_LOCATION permission

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,11 +1,12 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.reactlibrary">
-          <uses-permission android:name="android.permission.INTERNET" />
-          <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+          <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+          <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
           <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
           <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
-          <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+          <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+          <uses-permission android:name="android.permission.INTERNET" />
           <uses-permission android:name="android.permission.WRITE_SETTINGS" />
 </manifest>
   


### PR DESCRIPTION
Android 9 and later requires more permissions to call `WifiManager.getScanResults()` -- see
https://developer.android.com/guide/topics/connectivity/wifi-scan for details